### PR TITLE
Rename map to avoid clashes

### DIFF
--- a/proto/controller.proto
+++ b/proto/controller.proto
@@ -115,7 +115,7 @@ message GetGameReply { game.Game game = 1; }
 message CreateGameRequest {
   int32 player_id = 1;
   string name = 2;
-  game.Map map = 3;
+  game.Wc3Map map = 3;
   bool is_private = 4;
   bool is_live = 5;
 }
@@ -124,7 +124,7 @@ message CreateGameReply { game.Game game = 1; }
 
 message CreateGameAsBotRequest {
   string name = 2;
-  game.Map map = 3;
+  game.Wc3Map map = 3;
   bool is_private = 4;
   bool is_live = 5;
   int32 node_id = 6;

--- a/proto/game.proto
+++ b/proto/game.proto
@@ -10,7 +10,7 @@ message Game {
   int32 id = 1;
   string name = 2;
   GameStatus status = 3;
-  Map map = 4;
+  Wc3Map map = 4;
   repeated Slot slots = 5;
   node.Node node = 6;
   bool is_private = 7;
@@ -91,7 +91,7 @@ enum SlotClientStatus {
   SlotClientStatusLeft = 5;
 }
 
-message Map {
+message Wc3Map {
   bytes sha1 = 1;
   uint32 checksum = 2;
   string name = 3;


### PR DESCRIPTION
The name `Map` is already used for (Hash)Maps, hence renaming to avoid clashes during code generation.

As gRPC does not care about names of types, this will not cause any issues.